### PR TITLE
Task/Bypass error throw in server side for SSG pages

### DIFF
--- a/src/core/api/index.tsx
+++ b/src/core/api/index.tsx
@@ -32,6 +32,6 @@ export const api = async <T,>(
       return response;
     }
   } catch (error) {
-    throwError(error);
+    return isServer ? undefined : throwError(error);
   }
 }


### PR DESCRIPTION
Bypasses the error throw after an unsuccessfull API request in server side.
This allows SSG pages content within an initial request call to render.